### PR TITLE
Add specializations controller

### DIFF
--- a/app/controllers/api/v1/specializations_controller.rb
+++ b/app/controllers/api/v1/specializations_controller.rb
@@ -1,0 +1,25 @@
+class Api::V1::SpecializationsController < ApplicationController
+    before_action :authenticate_user!
+
+    # GET api/v1/specializations
+    def index
+        specializations = Specialization.all
+        render json: specializations
+    end
+
+    # POST api/v1/specializations
+    def create
+        specialization = Specialization.new(specialization_params)
+        if specialization.save
+            render json: specialization, status: :created
+        else
+            render json: specialization.errors, status: :unprocessable_entity
+        end
+    end
+
+    private
+
+    def specialization_params
+        params.require(:specialization).permit(:name)
+    end
+end

--- a/app/controllers/api/v1/specializations_controller.rb
+++ b/app/controllers/api/v1/specializations_controller.rb
@@ -1,25 +1,25 @@
 class Api::V1::SpecializationsController < ApplicationController
-    before_action :authenticate_user!
+  before_action :authenticate_user!
 
-    # GET api/v1/specializations
-    def index
-        specializations = Specialization.all
-        render json: specializations
+  # GET api/v1/specializations
+  def index
+    specializations = Specialization.all
+    render json: specializations
+  end
+
+  # POST api/v1/specializations
+  def create
+    specialization = Specialization.new(specialization_params)
+    if specialization.save
+      render json: specialization, status: :created
+    else
+      render json: specialization.errors, status: :unprocessable_entity
     end
+  end
 
-    # POST api/v1/specializations
-    def create
-        specialization = Specialization.new(specialization_params)
-        if specialization.save
-            render json: specialization, status: :created
-        else
-            render json: specialization.errors, status: :unprocessable_entity
-        end
-    end
+  private
 
-    private
-
-    def specialization_params
-        params.require(:specialization).permit(:name)
-    end
+  def specialization_params
+    params.require(:specialization).permit(:name)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     namespace :v1, defaults: { format: 'json' } do
       resources :doctors, only: [:index, :show, :new, :create, :destroy] 
       resources :appointments, only: [:index, :show, :new, :create, :destroy]
+      resources :specializations, only: [:index, :create]
     end
   end
 end

--- a/test/controllers/api/v1/specializations_controller_test.rb
+++ b/test/controllers/api/v1/specializations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::SpecializationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/api/v1/specializations_controller_test.rb
+++ b/test/controllers/api/v1/specializations_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class Api::V1::SpecializationsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do


### PR DESCRIPTION
Hi,

This PR is raised to add `specializations controller`. 
- To make a `GET` request use the end point : **localhost:3000/api/v1/specializations**
- To make a `POST` request use the end point: **localhost:3000/api/v1/specializations** with body as 
`{ "specializations" : 
                {
                  "name" : "specialty name"
                }
}`

Thanks.